### PR TITLE
Add viewbox attribute to SVG icons

### DIFF
--- a/icon-blacklist.svg
+++ b/icon-blacklist.svg
@@ -6,6 +6,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    id="svg2"
+   viewBox="0 0 64 64"
    height="64"
    width="64"
    version="1.1">

--- a/icon-off.svg
+++ b/icon-off.svg
@@ -6,6 +6,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    id="svg2"
+   viewBox="0 0 64 64"
    height="64"
    width="64"
    version="1.1">

--- a/icon-whitelist.svg
+++ b/icon-whitelist.svg
@@ -6,6 +6,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    id="svg2"
+   viewBox="0 0 64 64"
    height="64"
    width="64"
    version="1.1">

--- a/icon.svg
+++ b/icon.svg
@@ -6,6 +6,7 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    id="svg2"
+   viewBox="0 0 64 64"
    height="64"
    width="64"
    version="1.1">


### PR DESCRIPTION
Fixes rendering in Photon and conforms [recommendation](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/manifest.json/icons#SVG) for using SVG extension icon.

Before:
![](https://user-images.githubusercontent.com/705123/27513298-4bd35470-5961-11e7-9499-2c4914406207.png)

After:
![](https://user-images.githubusercontent.com/705123/27513297-4bcfcddc-5961-11e7-8856-e0cf247e02bb.png)
